### PR TITLE
Improve navigation to and from subpages

### DIFF
--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -314,8 +314,8 @@ colorWithAlpha alpha color =
     Element.rgba red green blue alpha
 
 
-header : LoadedModel -> Element msg
-header model =
+header : { windowSize : ( Int, Int ), isCompact : Bool } -> Element msg
+header config =
     let
         glow =
             Element.Font.glow (colorWithAlpha 0.25 colors.defaultText) 4
@@ -326,29 +326,36 @@ header model =
         logoAltText =
             "The logo of Elm Camp, a tangram in green forest colors"
 
+        titleSize =
+            if windowWidth < 800 then
+                64
+
+            else
+                80
+
+        elmCampTitle =
+            Element.link
+                []
+                { url = Route.encode HomepageRoute
+                , label = Element.el [ Element.Font.size titleSize, glow, Element.paddingXY 0 8 ] (Element.text "Elm Camp")
+                }
+
         ( windowWidth, _ ) =
-            model.windowSize
+            config.windowSize
     in
-    if windowWidth < 1000 then
+    if windowWidth < 1000 || config.isCompact then
         Element.column
             [ Element.padding 30, Element.spacing 20, Element.centerX ]
-            [ Element.image
-                [ Element.width (Element.maximum 523 Element.fill) ]
-                { src = "/logo.webp", description = illustrationAltText }
+            [ if config.isCompact then
+                Element.none
+
+              else
+                Element.image
+                    [ Element.width (Element.maximum 523 Element.fill) ]
+                    { src = "/logo.webp", description = illustrationAltText }
             , Element.column
                 [ Element.spacing 24, Element.centerX ]
-                [ Element.el
-                    [ Element.Font.size
-                        (if windowWidth < 800 then
-                            64
-
-                         else
-                            80
-                        )
-                    , glow
-                    , Element.paddingXY 0 8
-                    ]
-                    (Element.text "Elm Camp")
+                [ elmCampTitle
                 , Element.row
                     [ Element.centerX, Element.spacing 13 ]
                     [ Element.image
@@ -376,12 +383,7 @@ header model =
                 { src = "/logo.webp", description = illustrationAltText }
             , Element.column
                 [ Element.spacing 24 ]
-                [ Element.el
-                    [ Element.Font.size 80
-                    , glow
-                    , Element.paddingXY 0 8
-                    ]
-                    (Element.text "Elm Camp")
+                [ elmCampTitle
                 , Element.row
                     [ Element.centerX, Element.spacing 13 ]
                     [ Element.image
@@ -437,7 +439,8 @@ loadedView model =
         AccessibilityRoute ->
             Element.column
                 [ Element.width Element.fill, Element.height Element.fill ]
-                [ Element.column
+                [ header { windowSize = model.windowSize, isCompact = True }
+                , Element.column
                     contentAttributes
                     [ accessibilityContent
                     ]
@@ -447,7 +450,8 @@ loadedView model =
         CodeOfConductRoute ->
             Element.column
                 [ Element.width Element.fill, Element.height Element.fill ]
-                [ Element.column
+                [ header { windowSize = model.windowSize, isCompact = True }
+                , Element.column
                     contentAttributes
                     [ codeOfConductContent
                     ]
@@ -551,7 +555,7 @@ homepageView model =
                     , Element.width Element.fill
                     , Element.paddingEach { left = sidePadding, right = sidePadding, top = 0, bottom = 24 }
                     ]
-                    [ header model
+                    [ header { windowSize = model.windowSize, isCompact = False }
                     , Element.column
                         [ Element.width Element.fill, Element.spacing 40 ]
                         [ Element.column


### PR DESCRIPTION
Three little tweaks:

- Show a header with link back to home page on subpages (using the existing compact header)
- Jump to top of page when route changes
- Alt texts changed to give sense of image contents

@supermario I am not sure whether scrolling to the top whenever the route changes is too much, does it mess with the checkout flow?

![image](https://user-images.githubusercontent.com/47458/230597325-63bfb9b6-9060-43e7-bfc7-fbe58a773a32.png)
