### PR TITLE
♻️ Archive '23 details  

### DIFF
--- a/src/Camp23Denmark.elm
+++ b/src/Camp23Denmark.elm
@@ -1,5 +1,6 @@
 module Camp23Denmark exposing (..)
 
+import Camp23Denmark.Archive
 import Camp23Denmark.Artifacts
 import Element
 import Element.Font
@@ -9,31 +10,31 @@ import Theme
 
 
 view model subpage =
-    case subpage of
-        Home ->
-            Element.text "todo"
-
-        Artifacts ->
-            Element.column
-                [ Element.width Element.fill, Element.height Element.fill ]
-                [ Element.column
-                    (Element.padding 20 :: Theme.contentAttributes ++ [ Element.spacing 50 ])
-                    [ Theme.rowToColumnWhen 700
-                        model
-                        [ Element.spacing 30, Element.centerX, Element.Font.center ]
-                        [ Element.image
-                            [ Element.width (Element.px 300) ]
-                            { src = "/23-denmark/artifacts.png", description = "A suitcase full of artifacts in the middle of a danish forest" }
-                        , Element.column [ Element.width Element.fill, Element.spacing 20 ]
-                            [ Element.paragraph [ Element.Font.size 50, Element.Font.center ] [ Element.text "Artifacts" ]
-                            , elmCampDenmarkTopLine
-                            , elmCampDenmarkBottomLine
-                            ]
-                        ]
-                    , Camp23Denmark.Artifacts.view model
+    Element.column
+        [ Element.width Element.fill, Element.height Element.fill ]
+        [ Element.column
+            (Element.padding 20 :: Theme.contentAttributes ++ [ Element.spacing 50 ])
+            [ Theme.rowToColumnWhen 700
+                model
+                [ Element.spacing 30, Element.centerX, Element.Font.center ]
+                [ Element.image
+                    [ Element.width (Element.px 300) ]
+                    { src = "/23-denmark/artifacts.png", description = "A suitcase full of artifacts in the middle of a danish forest" }
+                , Element.column [ Element.width Element.fill, Element.spacing 20 ]
+                    [ Element.paragraph [ Element.Font.size 50, Element.Font.center ] [ Element.text "Archive" ]
+                    , elmCampDenmarkTopLine
+                    , elmCampDenmarkBottomLine
                     ]
-                , Theme.footer
                 ]
+            , case subpage of
+                Home ->
+                    Camp23Denmark.Archive.view model
+
+                Artifacts ->
+                    Camp23Denmark.Artifacts.view model
+            ]
+        , Theme.footer
+        ]
 
 
 elmCampDenmarkTopLine =

--- a/src/Camp23Denmark/Archive.elm
+++ b/src/Camp23Denmark/Archive.elm
@@ -1,0 +1,246 @@
+module Camp23Denmark.Archive exposing (view)
+
+import Browser exposing (UrlRequest(..))
+import Element exposing (Element)
+import Element.Background
+import Element.Border
+import Element.Font
+import Element.Input
+import MarkdownThemed
+import PurchaseForm exposing (PressedSubmit(..), PurchaseFormValidated(..), SubmitStatus(..))
+import Route exposing (Route(..), SubPage(..))
+import Stripe exposing (ProductId(..))
+import Theme
+import Types exposing (..)
+
+
+view model =
+    Element.column
+        [ Element.width Element.fill, Element.spacing 40 ]
+        [ Element.column
+            Theme.contentAttributes
+            [ content1, unconferenceBulletPoints model ]
+        , if model.window.width > 950 then
+            [ "image1.webp", "image2.webp", "image3.webp", "image4.webp", "image5.webp", "image6.webp" ]
+                |> List.map (dallundCastleImage (Element.px 288))
+                |> Element.wrappedRow
+                    [ Element.spacing 10, Element.width (Element.px 900), Element.centerX ]
+
+          else
+            [ [ "image1.webp", "image2.webp" ]
+            , [ "image3.webp", "image4.webp" ]
+            , [ "image5.webp", "image6.webp" ]
+            ]
+                |> List.map
+                    (\paths ->
+                        Element.row
+                            [ Element.spacing 10, Element.width Element.fill ]
+                            (List.map (dallundCastleImage Element.fill) paths)
+                    )
+                |> Element.column [ Element.spacing 10, Element.width Element.fill ]
+        , Element.column
+            Theme.contentAttributes
+            [ MarkdownThemed.renderFull "# Our sponsors"
+            , sponsors model.window
+            ]
+        , Element.column
+            [ Element.width Element.fill
+            , Element.spacing 24
+            ]
+            [ Element.el Theme.contentAttributes content2
+            , Element.el Theme.contentAttributes content3
+            ]
+        ]
+
+
+dallundCastleImage : Element.Length -> String -> Element msg
+dallundCastleImage width path =
+    Element.image
+        [ Element.width width ]
+        { src = "/" ++ path, description = "Photo of part of the Dallund Castle" }
+
+
+content1 : Element msg
+content1 =
+    """
+Elm Camp brings an opportunity for Elm makers & tool builders to gather, communicate and collaborate. Our goal is to strengthen and sustain the Elm ecosystem and community.
+
+Elm Camp is an event geared towards reconnecting in-person and collaborating on the current and future community landscape of the Elm ecosystem that surrounds the Elm core language.
+
+Over the last few years, Elm has seen community-driven tools and libraries expanding the potential and utility of the Elm language, stemming from a steady pace of continued commercial and hobbyist adoption.
+
+There is great potential for progress and innovation in a creative, focused, in-person gathering. It’s been a long while since we’ve had this opportunity for folks who are investing in the future of Elm. We expect the wider community and practitioners to benefit from this collaborative exploration of our problems and goals.
+
+Elm Camp is the first Elm Unconference. Our intention is to debut as a small, casual and low-stress event, paving the way for future Elm Camps across the world.
+
+# The Unconference
+
+"""
+        |> MarkdownThemed.renderFull
+
+
+unconferenceBulletPoints : LoadedModel -> Element FrontendMsg_
+unconferenceBulletPoints model =
+    [ Element.text "Arrive 3pm Wed 28 June"
+    , Element.text "Depart 4pm Fri 30 June"
+    , Element.text "Dallund Castle, Denmark"
+    , Element.text "Daily opener un-keynote"
+    , Element.text "Collaborative session creation throughout"
+    , Element.text "Countless hallway conversations and mealtime connections"
+    , Element.text "Access to full castle grounds including lake swimming"
+    , Element.el
+        [ (if model.showTooltip then
+            tooltip "This is our first Elm Unconference, so we're starting small and working backwards from a venue. We understand that this might mean some folks miss out this year – we plan to take what we learn & apply it to the next event. If you know of a bigger venue that would be suitable for future years, please let the team know!"
+
+           else
+            Element.none
+          )
+            |> Element.below
+        ]
+        (Element.Input.button
+            []
+            { onPress = Just PressedShowTooltip, label = Element.text "50 attendees ℹ️" }
+        )
+    ]
+        |> List.map (\point -> MarkdownThemed.bulletPoint [ point ])
+        |> Element.column [ Element.spacing 15 ]
+
+
+tooltip : String -> Element msg
+tooltip text =
+    Element.paragraph
+        [ Element.paddingXY 12 8
+        , Element.Background.color (Element.rgb 1 1 1)
+        , Element.width (Element.px 300)
+        , Element.Border.shadow { offset = ( 0, 1 ), size = 0, blur = 4, color = Element.rgba 0 0 0 0.25 }
+        ]
+        [ Element.text text ]
+
+
+content2 : Element msg
+content2 =
+    """
+# Opportunity grants
+
+**Thanks to Concentric and generous individual sponsors for making the opportunity grants possible**.
+
+
+# Schedule
+
+## Wed 28th June
+
+* 3pm - Arrivals & halls officially open
+* 6pm - Opening of session board
+* 7pm - Informal dinner
+* 8:30pm+ Evening stroll and informal chats
+* 9:57pm - 🌅Sunset
+
+## Thu 29th June
+
+* 7am-9am - Breakfast
+* 9am - Opening Unkeynote
+* 10am-12pm - Unconference sessions
+* 12-1:30pm - Lunch
+* 2pm-5pm Unconference sessions
+* 6-7:30pm Dinner
+* Onwards - Board Games and informal chats
+
+## Fri 30th June
+
+* 7am-9am - Breakfast
+* 9am - 12pm Unconference sessions
+* 12-1:30pm - Lunch
+* 2pm Closing Unkeynote
+* 3pm unconference wrap-up
+* 4pm - Departure
+
+# Travel and Accommodation
+
+Elm Camp takes place at Dallund Castle near Odense in Denmark.
+
+Odense can be reached directly by train from Hamburg, Copenhagen and other locations in Denmark. Denmark has multiple airports for attendants arriving from distant locations.
+
+Dallund Castle itself offers 24 rooms, additional accommodation can be found in Odense.
+
+All meals are organic or biodynamic and the venue can accommodate individual allergies & intolerances. Lunches will be vegetarian, dinners will include free-range & organic meat with a vegetarian option.
+
+More details can be found on our [venue & access page](/venue-and-access).
+
+# Organisers
+
+Elm Camp is a community-driven non-profit initiative, organised by enthusiastic members of the Elm community.
+
+🇬🇧 Katja Mordaunt – Uses web tech to help improve the reach of charities, artists, activists & community groups. Industry advocate for functional & Elm. Co-founder of codereading.club
+
+🇺🇸 James Carlson – Developer of [Scripta.io](https://scripta.io), a web publishing platform for technical documents in mathematics, physics, and the like. Currently working for [exosphere.app](https://exosphere.app), an all-Elm cloud-computing project
+
+🇸🇪 Martin Stewart – Makes games and apps using Lamdera. Also runs the state-of-elm survey every year.
+
+🇨🇿 Martin Janiczek – Loves to start things and one-off experiments, has a drive for teaching and unblocking others. Regularly races for the first answer in Elm Slack #beginners and #help.
+
+🇬🇧 Mario Rogic – Organiser of the Elm London and Elm Online meetups. Groundskeeper of Elmcraft, founder of Lamdera.
+
+🇩🇪 Johannes Emerich – Works at Dividat, making a console with small games and a large controller. Remembers when Elm demos were about the intricacies of how high Super Mario jumps."""
+        |> MarkdownThemed.renderFull
+
+
+content3 =
+    """
+# Something else?
+
+Problem with something above? Get in touch with the team at [team@elm.camp](mailto:team@elm.camp)."""
+        |> MarkdownThemed.renderFull
+
+
+sponsors : { window | width : Int } -> Element msg
+sponsors window =
+    let
+        asImg { image, url, width } =
+            Element.newTabLink
+                [ Element.width Element.fill ]
+                { url = url
+                , label =
+                    Element.image
+                        [ Element.width
+                            (Element.px
+                                (if window.width < 800 then
+                                    toFloat width * 0.7 |> round
+
+                                 else
+                                    width
+                                )
+                            )
+                        ]
+                        { src = "/sponsors/" ++ image, description = url }
+                }
+    in
+    [ asImg { image = "vendr.png", url = "https://www.vendr.com/", width = 250 }
+    , asImg { image = "concentrichealthlogo.svg", url = "https://concentric.health/", width = 250 }
+    , asImg { image = "logo-dividat.svg", url = "https://dividat.com", width = 170 }
+    , asImg { image = "lamdera-logo-black.svg", url = "https://lamdera.com/", width = 200 }
+    , asImg { image = "scripta.io.svg", url = "https://scripta.io", width = 200 }
+    , asImg { image = "bekk.svg", url = "https://www.bekk.no/", width = 200 }
+    , Element.newTabLink
+        [ Element.width Element.fill ]
+        { url = "https://www.elmweekly.nl"
+        , label =
+            Element.row [ Element.spacing 10, Element.width (Element.px 200) ]
+                [ Element.image
+                    [ Element.width
+                        (Element.px
+                            (if window.width < 800 then
+                                toFloat 60 * 0.7 |> round
+
+                             else
+                                60
+                            )
+                        )
+                    ]
+                    { src = "/sponsors/" ++ "elm-weekly.svg", description = "https://www.elmweekly.nl" }
+                , Element.el [ Element.Font.size 24 ] <| Element.text "Elm Weekly"
+                ]
+        }
+    , asImg { image = "cookiewolf-logo.png", url = "", width = 220 }
+    ]
+        -- |> List.map asImg
+        |> Element.wrappedRow [ Element.spacing 32 ]

--- a/src/Camp23Denmark/Artifacts.elm
+++ b/src/Camp23Denmark/Artifacts.elm
@@ -1,4 +1,4 @@
-module Camp23Denmark.Artifacts exposing (view)
+module Camp23Denmark.Artifacts exposing (media, posts, view)
 
 import MarkdownThemed
 
@@ -6,8 +6,14 @@ import MarkdownThemed
 view model =
     """
 This page is [open to contributions on Github](https://github.com/elm-camp/website/edit/main/src/Camp23Denmark/Artifacts.elm).
+"""
+        ++ posts
+        ++ media
+        |> MarkdownThemed.renderFull
 
 
+posts =
+    """
 ## Posts
 
 - [Elm Camp June 2023 Session Overview](https://discourse.elm-lang.org/t/elm-camp-june-2023-session-overview/9218) by @marcw (Discourse)
@@ -15,10 +21,13 @@ This page is [open to contributions on Github](https://github.com/elm-camp/websi
 - [Elm Camp session about editors and IDE plugins](https://discourse.elm-lang.org/t/elm-camp-session-about-editors-and-ide-plugins/9230) by @lydell (Discourse)
 - [Worst Elm Code Possible – Or, the checklist for good Elm, and the one thing to be careful to avoid](https://discourse.elm-lang.org/t/the-worst-elm-code-possible/9380) by @supermario (Discourse/Post)
 
+"""
+
+
+media =
+    """
 ## Media
 
 <img src="/camps/23-denmark/elm-camp-23-attendees.jpeg" width="100%" />
 
-
 """
-        |> MarkdownThemed.renderFull

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -1149,7 +1149,7 @@ Last year, we were able to offer opportunity grants to cover both ticket and tra
 
 **Thanks to Concentric and generous individual sponsors for making the Elm Camp 2023 opportunity grants possible**.
 
-# Organisers
+# 2024 Organisers
 
 Elm Camp is a community-driven non-profit initiative, organised by enthusiastic members of the Elm community.
 

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -440,6 +440,19 @@ header config =
                 { url = Route.encode HomepageRoute
                 , label = Element.el [ Element.Font.size titleSize, Theme.glow, Element.paddingXY 0 8 ] (Element.text "Elm Camp")
                 }
+
+        elmCampNextTopLine =
+            Element.row
+                [ Element.centerX, Element.spacing 13 ]
+                [ Element.image
+                    [ Element.width (Element.px 49) ]
+                    { src = "/elm-camp-tangram.webp", description = "The logo of Elm Camp, a tangram in green forest colors" }
+                , Element.column
+                    [ Element.spacing 2, Element.Font.size 24, Element.moveUp 1 ]
+                    [ Element.el [ Theme.glow ] (Element.text "Unconference")
+                    , Element.el [ Element.Font.extraBold, Element.Font.color MarkdownThemed.lightTheme.elmText ] (Element.text "Planet Earth 2024")
+                    ]
+                ]
     in
     if config.window.width < 1000 || config.isCompact then
         Element.column
@@ -454,8 +467,7 @@ header config =
             , Element.column
                 [ Element.spacing 24, Element.centerX ]
                 [ elmCampTitle
-                , Camp23Denmark.elmCampDenmarkTopLine
-                , Camp23Denmark.elmCampDenmarkBottomLine
+                , elmCampNextTopLine
                 ]
             ]
 
@@ -468,8 +480,7 @@ header config =
             , Element.column
                 [ Element.spacing 24 ]
                 [ elmCampTitle
-                , Camp23Denmark.elmCampDenmarkTopLine
-                , Camp23Denmark.elmCampDenmarkBottomLine
+                , elmCampNextTopLine
                 ]
             ]
 
@@ -635,9 +646,6 @@ ticketsHtmlId =
 homepageView : LoadedModel -> Element FrontendMsg_
 homepageView model =
     let
-        padding =
-            Element.paddingXY sidePadding 24
-
         sidePadding =
             if model.window.width < 800 then
                 24
@@ -645,97 +653,34 @@ homepageView model =
             else
                 60
     in
-    case model.selectedTicket of
-        Just ( productId, priceId ) ->
-            case AssocList.get productId Tickets.dict of
-                Just ticket ->
-                    Element.column
-                        (Element.spacing 24 :: padding :: Theme.contentAttributes)
-                        [ Element.row
-                            [ Element.spacing 16, Element.width Element.fill ]
-                            [ Element.image
-                                [ Element.width (Element.px 50) ]
-                                { src = ticket.image, description = "Illustration of a cozy camp site at evening time" }
-                            , Element.paragraph
-                                [ Element.Font.size 24 ]
-                                [ Element.el [ Element.Font.semiBold ] (Element.text ticket.name)
-                                , case AssocList.get productId model.prices of
-                                    Just { price } ->
-                                        " - "
-                                            ++ Theme.priceText price
-                                            |> Element.text
-
-                                    Nothing ->
-                                        Element.none
-                                ]
-                            ]
-                        , Element.paragraph [] [ MarkdownThemed.renderFull ticket.description ]
-                        , formView model productId priceId ticket
-                        ]
-
-                Nothing ->
-                    Element.text "Ticket not found"
-
-        Nothing ->
-            Element.column
-                [ Element.width Element.fill ]
-                [ Element.column
-                    [ Element.spacing 50
-                    , Element.width Element.fill
-                    , Element.paddingEach { left = sidePadding, right = sidePadding, top = 0, bottom = 24 }
+    Element.column
+        [ Element.width Element.fill ]
+        [ Element.column
+            [ Element.spacing 50
+            , Element.width Element.fill
+            , Element.paddingEach { left = sidePadding, right = sidePadding, top = 0, bottom = 24 }
+            ]
+            [ header { window = model.window, isCompact = False }
+            , Element.column
+                [ Element.width Element.fill, Element.spacing 40 ]
+                [ Element.column Theme.contentAttributes [ content1 ]
+                , Element.column
+                    Theme.contentAttributes
+                    [ MarkdownThemed.renderFull "# Last year's sponsors"
+                    , sponsors model.window
                     ]
-                    [ header { window = model.window, isCompact = False }
-                    , Element.column
-                        [ Element.width Element.fill, Element.spacing 40 ]
-                        [ Element.column
-                            Theme.contentAttributes
-                            [ content1, unconferenceBulletPoints model ]
-                        , if model.window.width > 950 then
-                            [ "image1.webp", "image2.webp", "image3.webp", "image4.webp", "image5.webp", "image6.webp" ]
-                                |> List.map (dallundCastleImage (Element.px 288))
-                                |> Element.wrappedRow
-                                    [ Element.spacing 10, Element.width (Element.px 900), Element.centerX ]
-
-                          else
-                            [ [ "image1.webp", "image2.webp" ]
-                            , [ "image3.webp", "image4.webp" ]
-                            , [ "image5.webp", "image6.webp" ]
-                            ]
-                                |> List.map
-                                    (\paths ->
-                                        Element.row
-                                            [ Element.spacing 10, Element.width Element.fill ]
-                                            (List.map (dallundCastleImage Element.fill) paths)
-                                    )
-                                |> Element.column [ Element.spacing 10, Element.width Element.fill ]
-                        , Element.column
-                            Theme.contentAttributes
-                            [ MarkdownThemed.renderFull "# Our sponsors"
-                            , sponsors model.window
-                            ]
-                        , Element.column
-                            [ Element.width Element.fill
-                            , Element.spacing 24
-                            , Element.htmlAttribute (Html.Attributes.id ticketsHtmlId)
-                            ]
-                            [ Element.column
-                                (Element.spacing 16 :: Theme.contentAttributes)
-                                [ MarkdownThemed.renderFull <|
-                                    """
-# Tickets
-"""
-                                , ticketCardsView model
-                                , Theme.viewIf (Inventory.allSoldOut model.slotsRemaining) <|
-                                    MarkdownThemed.renderFull <|
-                                        """**Missed out on a ticket? Send an email to [team@elm.camp](mailto:team@elm.camp) and we'll add you to the Campfire Ticket wait list.**"""
-                                ]
-                            , Element.el Theme.contentAttributes content2
-                            , Element.el Theme.contentAttributes content3
-                            ]
-                        ]
+                , Element.column
+                    [ Element.width Element.fill
+                    , Element.spacing 24
+                    , Element.htmlAttribute (Html.Attributes.id ticketsHtmlId)
                     ]
-                , Theme.footer
+                    [ Element.el Theme.contentAttributes content2
+                    , Element.el Theme.contentAttributes content3
+                    ]
                 ]
+            ]
+        , Theme.footer
+        ]
 
 
 
@@ -1162,39 +1107,14 @@ Over the last few years, Elm has seen community-driven tools and libraries expan
 
 There is great potential for progress and innovation in a creative, focused, in-person gathering. It’s been a long while since we’ve had this opportunity for folks who are investing in the future of Elm. We expect the wider community and practitioners to benefit from this collaborative exploration of our problems and goals.
 
-Elm Camp is the first Elm Unconference. Our intention is to debut as a small, casual and low-stress event, paving the way for future Elm Camps across the world.
+Last year was our first Elm Camp and unconference. Our intention remains the same: to run as a small, casual and low-stress event, and pave the way for future Elm Camps across the world.
 
-# The Unconference
+# Help us plan Elm Camp 2024!
+
+We're still working out the details for Elm Camp 2024. We're on the hunt for a new venue, and we need your help! If you have ideas for a local (to you) venue, please take a few minutes to fill out our [venue survey](https://docs.google.com/forms/d/e/1FAIpQLSemvyUQURU_Dowyvp-5K6miBve5KWjoVTb9D65w82lrPpnBIg)
 
 """
         |> MarkdownThemed.renderFull
-
-
-unconferenceBulletPoints : LoadedModel -> Element FrontendMsg_
-unconferenceBulletPoints model =
-    [ Element.text "Arrive 3pm Wed 28 June"
-    , Element.text "Depart 4pm Fri 30 June"
-    , Element.text "Dallund Castle, Denmark"
-    , Element.text "Daily opener un-keynote"
-    , Element.text "Collaborative session creation throughout"
-    , Element.text "Countless hallway conversations and mealtime connections"
-    , Element.text "Access to full castle grounds including lake swimming"
-    , Element.el
-        [ (if model.showTooltip then
-            tooltip "This is our first Elm Unconference, so we're starting small and working backwards from a venue. We understand that this might mean some folks miss out this year – we plan to take what we learn & apply it to the next event. If you know of a bigger venue that would be suitable for future years, please let the team know!"
-
-           else
-            Element.none
-          )
-            |> Element.below
-        ]
-        (Element.Input.button
-            []
-            { onPress = Just PressedShowTooltip, label = Element.text "50 attendees ℹ️" }
-        )
-    ]
-        |> List.map (\point -> MarkdownThemed.bulletPoint [ point ])
-        |> Element.column [ Element.spacing 15 ]
 
 
 tooltip : String -> Element msg
@@ -1211,59 +1131,12 @@ tooltip text =
 content2 : Element msg
 content2 =
     """
-The venue has a capacity of 24 rooms, and 50 total attendees (i.e. on-site + external). Our plan is to prioritise ticket sales in the following order: """
-        ++ String.join ", " [ Tickets.couplesCampTicket.name, Tickets.campTicket.name, Tickets.campfireTicket.name ]
-        ++ """
 
 # Opportunity grants
 
-"""
-        ++ grantApplicationCopy
-        ++ """
+Last year, we were able to offer opportunity grants to cover both ticket and travel costs for a number of attendees who would otherwise not have been able to attend. We're still working out the details for next year's event, but we hope to be able to offer the same opportunity again.
 
-**Thanks to Concentric and generous individual sponsors for making the opportunity grants possible**.
-
-
-# Schedule
-
-## Wed 28th June
-
-* 3pm - Arrivals & halls officially open
-* 6pm - Opening of session board
-* 7pm - Informal dinner
-* 8:30pm+ Evening stroll and informal chats
-* 9:57pm - 🌅Sunset
-
-## Thu 29th June
-
-* 7am-9am - Breakfast
-* 9am - Opening Unkeynote
-* 10am-12pm - Unconference sessions
-* 12-1:30pm - Lunch
-* 2pm-5pm Unconference sessions
-* 6-7:30pm Dinner
-* Onwards - Board Games and informal chats
-
-## Fri 30th June
-
-* 7am-9am - Breakfast
-* 9am - 12pm Unconference sessions
-* 12-1:30pm - Lunch
-* 2pm Closing Unkeynote
-* 3pm unconference wrap-up
-* 4pm - Departure
-
-# Travel and Accommodation
-
-Elm Camp takes place at Dallund Castle near Odense in Denmark.
-
-Odense can be reached directly by train from Hamburg, Copenhagen and other locations in Denmark. Denmark has multiple airports for attendants arriving from distant locations.
-
-Dallund Castle itself offers 24 rooms, additional accommodation can be found in Odense.
-
-All meals are organic or biodynamic and the venue can accommodate individual allergies & intolerances. Lunches will be vegetarian, dinners will include free-range & organic meat with a vegetarian option.
-
-More details can be found on our [venue & access page](/venue-and-access).
+**Thanks to Concentric and generous individual sponsors for making the Elm Camp 2023 opportunity grants possible**.
 
 # Organisers
 
@@ -1287,49 +1160,9 @@ content3 =
     """
 # Sponsorship options
 
-Sponsoring Elm Camp gives your company the opportunity to support and connect with the Elm community. Your contribution helps members of the community to get together by keeping individual ticket prices at a reasonable level.
+Sponsoring Elm Camp gives your company the opportunity to support and connect with the Elm community. Your contribution helps members of the community to get together by keeping individual ticket prices at a reasonable level. 
 
-All levels of contribution are appreciated and acknowledged. Get in touch with the team at [team@elm.camp](mailto:team@elm.camp).
-
-## Bronze - less than €1000 EUR
-
-You will be an appreciated supporter of Elm Camp Europe 2023.
-
-* Listed as additional supporter on webpage
-
-## Silver - €1000 EUR  (£880 / $1100 USD)
-You will be a major supporter of Elm Camp Europe 2023.
-
-* Thank you tweet
-* Logo on webpage
-* Small logo on shared slide, displayed during breaks
-
-## Gold - €2500 EUR  (£2200 / $2700 USD)
-
-You will be a pivotal supporter of Elm Camp Europe 2023.
-
-* Thank you tweet
-* Rollup or poster inside the venue (provided by you)
-* Logo on webpage
-* Medium logo on shared slide, displayed during breaks
-* 1 free camp ticket
-
-## Platinum - €5000 EUR  (£4500 / $5300 USD)
-
-You will be principal sponsor and guarantee that Elm Camp Europe 2023 is a success.
-
-* Thank you tweet
-* Rollup or poster inside the venue (provided by you)
-* Self-written snippet on shared web page about use of Elm at your company
-* Logo on webpage
-* 2 free camp tickets
-* Big logo on shared slide, displayed during breaks
-* Honorary mention in opening and closing talks
-
-Limited to two.
-
-## Addon: Attendee Sponsor – €550
-You will make it possible for a student and/or underprivileged community member to attend Elm Camp Europe 2023.
+We haven’t worked out the detalis for Elm Camp 2024 yet, but if you're interested in sponsoring please get in touch with the team at [team@elm.camp](mailto:team@elm.camp).
 
 # Something else?
 

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -1173,7 +1173,7 @@ content3 =
 
 Sponsoring Elm Camp gives your company the opportunity to support and connect with the Elm community. Your contribution helps members of the community to get together by keeping individual ticket prices at a reasonable level. 
 
-We haven’t worked out the detalis for Elm Camp 2024 yet, but if you're interested in sponsoring please get in touch with the team at [team@elm.camp](mailto:team@elm.camp).
+If you're interested in sponsoring please get in touch with the team at [team@elm.camp](mailto:team@elm.camp).
 
 # Something else?
 

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -8,6 +8,7 @@ import Browser.Dom
 import Browser.Events
 import Browser.Navigation
 import Camp23Denmark
+import Camp23Denmark.Artifacts
 import Dict
 import Element exposing (Element)
 import Element.Background
@@ -1113,7 +1114,17 @@ Last year was our first Elm Camp and unconference. Our intention remains the sam
 
 We're still working out the details for Elm Camp 2024. We're on the hunt for a new venue, and we need your help! If you have ideas for a local (to you) venue, please take a few minutes to fill out our [venue survey](https://docs.google.com/forms/d/e/1FAIpQLSemvyUQURU_Dowyvp-5K6miBve5KWjoVTb9D65w82lrPpnBIg)
 
+# What happened at Elm Camp 2023
+
+Last year we ran a 3-day event in Odense, Denmark. Here are some of the memories folks have shared:
+
 """
+        ++ Camp23Denmark.Artifacts.posts
+        ++ Camp23Denmark.Artifacts.media
+        ++ """<br/>
+
+Did you attend Elm Camp 2023? We're [open to contributions on Github](https://github.com/elm-camp/website/edit/main/src/Camp23Denmark/Artifacts.elm)!
+        """
         |> MarkdownThemed.renderFull
 
 


### PR DESCRIPTION
- (Mostly) archives the '23 home page under `/23-denmark`
- New home page says we're planning for '24
  - CTA to fill out our venue survey
  - No details on sponsorship yet but contact us if you have sometime specific in mind
  - Says we hope to bring back the opportunity grants (right??)

I tried not to nuke too much of the old code (eg the ticket form) because presumably we'll want that back at some point and refactoring it felt out of scope of this. 