### PR TITLE
Scroll to error on submit, improve error message accessibility, align remove button

### DIFF
--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -995,10 +995,10 @@ errorHtmlId =
 errorText : String -> Element msg
 errorText error =
     paragraph
-        [ Font.color (rgb255 150 0 0)
+        [ Font.color (rgb255 172 0 0)
         , htmlAttribute (Html.Attributes.id errorHtmlId)
         ]
-        [ text error ]
+        [ text ("🚨 " ++ error) ]
 
 
 formView : LoadedModel -> Id ProductId -> Id PriceId -> Tickets.Ticket -> Element FrontendMsg_

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -343,7 +343,7 @@ updateLoaded msg model =
                             Debug.log "form invalid" ()
                     in
                     ( { model | form = { form | submitStatus = NotSubmitted PressedSubmit } }
-                    , Cmd.none
+                    , jumpToId errorHtmlId 110
                     )
 
                 _ ->
@@ -375,7 +375,7 @@ updateLoaded msg model =
                     ( { model | pressedAudioButton = True }, Cmd.none )
 
         SetViewPortForElement elmentId ->
-            ( model, jumpToId elmentId )
+            ( model, jumpToId elmentId 40 )
 
         Noop ->
             ( model, Cmd.none )
@@ -969,9 +969,25 @@ attendeeForm model i attendee =
         ]
 
 
+{-| Used to scroll to errors.
+
+It’s technically invalid to use the same ID multiple times, but in practice
+getting an element by ID means getting the _first_ element with that ID, which
+is exactly what we want here.
+
+-}
+errorHtmlId : String
+errorHtmlId =
+    "error"
+
+
 errorText : String -> Element msg
 errorText error =
-    paragraph [ Font.color (rgb255 150 0 0) ] [ text error ]
+    paragraph
+        [ Font.color (rgb255 150 0 0)
+        , htmlAttribute (Html.Attributes.id errorHtmlId)
+        ]
+        [ text error ]
 
 
 formView : LoadedModel -> Id ProductId -> Id PriceId -> Tickets.Ticket -> Element FrontendMsg_
@@ -1433,10 +1449,10 @@ goToTicketSales =
         }
 
 
-jumpToId : String -> Cmd FrontendMsg_
-jumpToId id =
+jumpToId : String -> Float -> Cmd FrontendMsg_
+jumpToId id offset =
     Browser.Dom.getElement id
-        |> Task.andThen (\el -> Browser.Dom.setViewport 0 (el.element.y - 40))
+        |> Task.andThen (\el -> Browser.Dom.setViewport 0 (el.element.y - offset))
         |> Task.attempt
             (\_ -> Noop)
 

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -915,16 +915,27 @@ attendeeForm model i attendee =
         form =
             model.form
 
+        columnWhen =
+            700
+
+        removeButtonAlignment =
+            if model.window.width > columnWhen then
+                -- This depends on the size of the text input labels.
+                15
+
+            else
+                0
+
         removeButton =
             Input.button
-                (normalButtonAttributes ++ [ width (px 100) ])
+                (normalButtonAttributes ++ [ width (px 100), alignTop, moveDown removeButtonAlignment ])
                 { onPress =
                     Just
                         (FormChanged { form | attendees = List.removeIfIndex (\j -> i == j) model.form.attendees })
                 , label = el [ centerX ] (text "Remove")
                 }
     in
-    Theme.rowToColumnWhen 700
+    Theme.rowToColumnWhen columnWhen
         model
         [ width fill, spacing 16 ]
         [ textInput


### PR DESCRIPTION
This PR contains three separate tweaks, as three commits. If one of them isn’t wanted, or you’d prefer three PRs, let me know and I’ll split things up!

# Scroll to error on submit

1. Click “Tickets on sale now! ⬇️”
2. Click “Select” at “🎟️ Attendance Ticket”
3. Scroll to the bottom and click “Purchase”

The page is now scrolled back up to the “🎟️ Attendance Ticket” where you didn’t fill anything out.

# Improve error message accessibility

| Thing | Before | After |
|-|-|-|
| Screenshot | <img width="819" alt="image" src="https://github.com/elm-camp/website/assets/2142817/5c752255-845f-4882-a801-2fc2d7cbbaf2"> | <img width="819" alt="image" src="https://github.com/elm-camp/website/assets/2142817/ddac60c7-4b0d-4829-9927-a458f51b1418"> |
| Color Contrast | [8.39:1 AAA pass](https://webaim.org/resources/contrastchecker/?fcolor=960000&bcolor=FFF4E1) | [7:1 AAA pass](https://webaim.org/resources/contrastchecker/?fcolor=AC0000&bcolor=FFF4E1) |

- The new color looks more distinctly red to my eyes, while the old one looks like the regular black test until I really focus on it.
- Added an icon to not only rely on color. I used an emoji since there are plenty of emojis used elsewhere.

Unfortunately the “Invalid email address” message no longer fits on one line, but not all of them did anyway. Let me known if you want me to do anything about that and have any ideas.

# Align Remove button

See the above screenshots. Before, the button “fell down” to the bottom of the error messages. Now it stays in place. The solution isn’t great (a magic number), but 🤷‍♂️ . I took care to not break the mobile layout.