### PR TITLE
Fix #47 -  Inconsistent spacing on CoC page

### DIFF
--- a/src/Camp25US.elm
+++ b/src/Camp25US.elm
@@ -70,28 +70,45 @@ conferenceSummary : Element msg
 conferenceSummary =
     """
 
-# Unconference
+# The Unconference
 
-- Arrive anytime on Tue 18th June 2024
+• Arrive anytime on Tues 24th June 2025
 
-- Depart 10am Fri 21st June 2024
+• Depart 10am on Fri 27th June 2025
 
-- 🇬🇧 Colehayes Park, Devon UK – [Venue & Access](https://elm.camp/venue-and-access)
+• 2 full days of talks
 
-- Collaborative session creation throughout
+• Location: Ronora Lodge and Retreat Center - Watervliet, Michigan
 
-- Periodic collective scheduling sessions
+• 60+ attendees
 
-- At least 3 tracks, sessions in both short and long blocks
+Prospective Schedule:
 
-- Countless hallway conversations and mealtime connections
+- Tue 24th June
+• 3pm arrivals & halls officially open
+• Opening of session board
+• Informal dinner
+• Evening stroll
 
-- Full and exclusive access to the Park grounds and facilities
+- Wed 25th June
+• Breakfast
+• Unconference sessions
+• Lunch
+• Unconference sessions
+• Dinner
+• Board Games and informal chats
 
-- 60+ attendees
+- Thu 26th June
+• Breakfast
+• Unconference sessions
+• Lunch
+• Unconference Sessions
+• Dinner
+• Unconference wrap-up & party
 
-
-**NOTE.** We will announce arrangements to get you from Exeter to Colehayes Park by shuttle closer to the event.  Exeter is easily accessible by train from London, Bristol, Birmingham and other major cities.
+- Fri 27th June
+• Grab and go breakfast
+• Depart by 10am
 
 """
         |> MarkdownThemed.renderFull

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -800,7 +800,7 @@ codeOfConductContent =
 # Code of Conduct
 
 Elm Camp welcomes people with a wide range of backgrounds, experiences and knowledge. We can learn a lot from each other. It's important for us to make sure the environment where these discussions happen is inclusive and supportive. Everyone should feel comfortable to participate! The following guidelines are meant to codify these intentions.
-
+<br/>
 ## Help everyone feel welcome at Elm Camp
 
 Everyone at Elm Camp is part of Elm Camp. There are a few staff on call and caterers preparing food, but there are no other guests on the grounds.
@@ -837,7 +837,7 @@ We expect everyone here to ensure that our community is harrassment-free for eve
 As a facilitator it's important that you not only follow our code of conduct, but also help to enforce it.
 
 If you have any concerns when planning, during or after your session, please get in touch with one of the organisers so we can help you.
-
+<br/>
 
 ## Talk to us
 


### PR DESCRIPTION
Added breaks between certain paragraphs for consistent spacing throughout the Code of Conduct page.