### PR TITLE
Don't store Svg in the Model

### DIFF
--- a/src/View/Logo.elm
+++ b/src/View/Logo.elm
@@ -1,4 +1,4 @@
-module View.Logo exposing (ConfigZipper, Model, Msg, Tangram, TangramPiece(..), init, update, view)
+module View.Logo exposing (ConfigZipper, Model, Msg, PieceConfig, Tangram, TangramPiece(..), init, update, view)
 
 import Effect.Test exposing (Button(..))
 import Html exposing (Html, div)


### PR DESCRIPTION
This should fix the problem with storing Svg in model. Now there is a custom type describing Tangram and it is resolved to SVG in view.