### PR TITLE
Default to EN sites of the venue

### DIFF
--- a/src/Camp26Czech.elm
+++ b/src/Camp26Czech.elm
@@ -243,7 +243,7 @@ Křelovská 91, 779 00 Olomouc 9<br/>
 Řepčín, Česko<br/>
 Czechia
 
-[https://www.hotel-pracharna.cz/](https://www.hotel-pracharna.cz/)
+[https://www.hotel-pracharna.cz/en/](https://www.hotel-pracharna.cz/en/)
 
 ## Participating in conversations
 

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -495,7 +495,7 @@ header config =
                     , Ui.el [ Ui.width Ui.shrink, Ui.Font.bold, Ui.Font.color Theme.lightTheme.defaultText ] (Ui.text Camp26Czech.location)
                     , Ui.el
                         [ Ui.width Ui.shrink, Ui.Font.bold, Ui.Font.color Theme.lightTheme.defaultText ]
-                        ("[Park Hotel Prachárna](https://www.hotel-pracharna.cz/)" |> MarkdownThemed.renderFull)
+                        ("[Park Hotel Prachárna](https://www.hotel-pracharna.cz/en/)" |> MarkdownThemed.renderFull)
                     , Ui.el
                         [ Ui.width Ui.shrink, Ui.Font.bold, Ui.Font.color Theme.lightTheme.defaultText ]
                         (Ui.text "Monday 15th - Thursday 18th June 2026")


### PR DESCRIPTION
Links for the venue points to the CZ sites. I think it would be better for them to point to EN sites by default, given our whole page is in EN for English speaking audience :)